### PR TITLE
build(deps): ⬆️ Upgrade dio dependency and add SDK constraint

### DIFF
--- a/core/data/pubspec.yaml
+++ b/core/data/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  dio: ^5.8.0+1
 
 dev_dependencies:
   flutter_test:

--- a/melos.yaml
+++ b/melos.yaml
@@ -2,3 +2,15 @@ name: multi_modular_flutter_project
 packages:
   - core/**
   - features/**
+
+command:
+  bootstrap:
+    environment:
+      sdk: ^3.7.2
+      flutter: ">=1.17.0"
+
+    dependencies:
+      dio: ^5.8.0+1
+
+    dev_dependencies:
+      flutter_lints: ^5.0.0


### PR DESCRIPTION
Updates dio dependency to version ^5.8.0+1 in core/data/pubspec.yaml. Adds SDK constraint to melos.yaml for flutter version compatibility.