### PR TITLE
feat(app): :sparkles: Integrate app settings module

### DIFF
--- a/features/settings/app_settings/lib/di/injection.config.dart
+++ b/features/settings/app_settings/lib/di/injection.config.dart
@@ -1,0 +1,37 @@
+// dart format width=80
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// InjectableConfigGenerator
+// **************************************************************************
+
+// ignore_for_file: type=lint
+// coverage:ignore-file
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:app_settings/provider/app_settings_provider.dart' as _i362;
+import 'package:app_settings/provider/app_settings_provider_impl.dart' as _i94;
+import 'package:get_it/get_it.dart' as _i174;
+import 'package:injectable/injectable.dart' as _i526;
+
+const String _dev = 'dev';
+const String _prod = 'prod';
+
+extension GetItInjectableX on _i174.GetIt {
+  // initializes the registration of main-scope dependencies inside of GetIt
+  _i174.GetIt init({
+    String? environment,
+    _i526.EnvironmentFilter? environmentFilter,
+  }) {
+    final gh = _i526.GetItHelper(this, environment, environmentFilter);
+    gh.factory<_i362.AppSettingsProvider>(
+      () => _i94.DevAppSettingsProviderImpl(),
+      registerFor: {_dev},
+    );
+    gh.factory<_i362.AppSettingsProvider>(
+      () => _i94.ProdAppSettingsProviderImpl(),
+      registerFor: {_prod},
+    );
+    return this;
+  }
+}

--- a/features/settings/app_settings/lib/di/injection.dart
+++ b/features/settings/app_settings/lib/di/injection.dart
@@ -1,0 +1,6 @@
+import 'package:get_it/get_it.dart';
+import 'package:injectable/injectable.dart';
+import 'package:app_settings/di/injection.config.dart';
+
+@InjectableInit()
+void configureAppSettingsInjection(GetIt getIt, String? environment) => getIt.init(environment: environment);

--- a/features/settings/app_settings/lib/provider/app_settings_provider.dart
+++ b/features/settings/app_settings/lib/provider/app_settings_provider.dart
@@ -1,0 +1,4 @@
+abstract class AppSettingsProvider {
+  String getAppLanguage();
+  String getThemeType();
+}

--- a/features/settings/app_settings/lib/provider/app_settings_provider_impl.dart
+++ b/features/settings/app_settings/lib/provider/app_settings_provider_impl.dart
@@ -1,0 +1,29 @@
+import 'package:injectable/injectable.dart';
+
+import 'app_settings_provider.dart';
+
+@Injectable(as: AppSettingsProvider, env: [Environment.prod])
+class ProdAppSettingsProviderImpl implements AppSettingsProvider {
+  @override
+  String getAppLanguage() {
+    return "en";
+  }
+
+  @override
+  String getThemeType() {
+    return "dark";
+  }
+}
+
+@Injectable(as: AppSettingsProvider, env: [Environment.dev])
+class DevAppSettingsProviderImpl implements AppSettingsProvider {
+  @override
+  String getAppLanguage() {
+    return "ar";
+  }
+
+  @override
+  String getThemeType() {
+    return "light";
+  }
+}

--- a/features/settings/app_settings/pubspec.yaml
+++ b/features/settings/app_settings/pubspec.yaml
@@ -10,11 +10,15 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  get_it: ^8.0.3
+  injectable: ^2.5.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
+  build_runner: ^2.4.15
+  injectable_generator: ^2.7.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/lib/di/injection.dart
+++ b/lib/di/injection.dart
@@ -1,3 +1,4 @@
+import 'package:app_settings/di/injection.dart';
 import 'package:get_it/get_it.dart';
 import 'package:injectable/injectable.dart';
 import 'package:multi_modular_flutter_project/di/injection.config.dart';
@@ -5,4 +6,7 @@ import 'package:multi_modular_flutter_project/di/injection.config.dart';
 final getIt = GetIt.instance;
 
 @InjectableInit()
-void configureInjection(String? environment) => getIt.init(environment: environment);
+void configureInjection(String? environment) {
+  getIt.init(environment: environment);
+  configureAppSettingsInjection(getIt, environment);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:app_settings/provider/app_settings_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:injectable/injectable.dart';
 
@@ -74,12 +75,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
   @override
   Widget build(BuildContext context) {
-    // This method is rerun every time setState is called, for instance as done
-    // by the _incrementCounter method above.
-    //
-    // The Flutter framework has been optimized to make rerunning build methods
-    // fast, so that you can just rebuild anything that needs updating rather
-    // than having to individually change instances of widgets.
+    final appSettingsProvider = getIt<AppSettingsProvider>();
     return Scaffold(
       appBar: AppBar(
         // TRY THIS: Try changing the color here to a specific color (to
@@ -109,9 +105,9 @@ class _MyHomePageState extends State<MyHomePage> {
           // wireframe for each widget.
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            const Text('You have pushed the button this many times:'),
+             Text("App Language: ${appSettingsProvider.getAppLanguage()}"),
             Text(
-              '$_counter',
+              "App Theme: ${appSettingsProvider.getThemeType()}",
               style: Theme.of(context).textTheme.headlineMedium,
             ),
           ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,6 +25,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.2+1"
+  app_settings:
+    dependency: "direct main"
+    description:
+      path: "features/settings/app_settings"
+      relative: true
+    source: path
+    version: "0.0.1"
   args:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,9 @@ dependencies:
   flutter:
     sdk: flutter
 
+  app_settings:
+    path: features/settings/app_settings
+    
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8


### PR DESCRIPTION
Adds the app_settings module to manage app language and theme.

This commit integrates the app_settings module, providing functionality to retrieve the app's language and theme. It includes the module itself, dependency injection setup, and displays the settings on the main screen for demonstration.